### PR TITLE
Bring ArgoCD PR Bot into our infrastructure (SC-1859)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "manifests": "kustomize build ./deployment/base > deployment/install.yaml"
   },
   "dependencies": {
+    "@types/bunyan": "^1.8.6",
     "@types/jest": "^24.0.11",
     "@types/node": "^11.13.4",
     "node-fetch": "^2.3.0",

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,6 @@
 name: argocd-bot
+tests:
+  primary:
+  - name: ezcater-config-nodejs
+    build: .
+    command: tail -f /dev/null

--- a/service.yaml
+++ b/service.yaml
@@ -1,6 +1,6 @@
 name: argocd-bot
 tests:
   primary:
-  - name: ezcater-config-nodejs
+  - name: argocd-bot
     build: .
     command: tail -f /dev/null

--- a/service.yaml
+++ b/service.yaml
@@ -1,4 +1,6 @@
 name: argocd-bot
+slack: pb-argocd-notifications
+owner: sre
 tests:
   primary:
   - name: argocd-bot

--- a/test/argo.diff.test.ts
+++ b/test/argo.diff.test.ts
@@ -1,5 +1,5 @@
 import * as sinon from "sinon"
-import * as nock from "nock"
+const nock = require('nock')
 import { Probot } from 'probot'
 
 const ArgocdBot = require("..")

--- a/test/argo.misc.test.ts
+++ b/test/argo.misc.test.ts
@@ -1,5 +1,5 @@
 import * as sinon from "sinon"
-import * as nock from "nock"
+const nock = require('nock')
 import { Probot } from "probot"
 
 const ArgocdBot = require("..")

--- a/test/argo.pr_locking.test.ts
+++ b/test/argo.pr_locking.test.ts
@@ -1,5 +1,5 @@
 import * as sinon from "sinon"
-import * as nock from "nock"
+const nock = require('nock')
 import { Probot } from "probot"
 
 const ArgocdBot = require("..")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "compilerOptions": {
         "outDir": "./lib",
         "allowJs": true,
-        "target": "es5"
+        "target": "es5",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
     },
     "include": [
         "./src/**/*",


### PR DESCRIPTION
The purpose of this pull request is to setup a pipeline for the argocd-bot. I did test that this does work in lab. 

I'm slightly concerned about the `"skipLibCheck": true` compiler option since this will bypass tslint for dependencies. Without this, probot fails validation. I'm not quite sure if they used an older version of tslint to build images successfully. I tried a number of older versions of the argocd image itself, unsuccessfully. The issue is that the probot package references the octokit package and doesn't specify the Generic type argument for a few of the types. This is still an issue in the probot codebase, which includes the `"skipLibCheck": true` compiler option, which explains why they don't have issues in their project.

https://github.com/probot/probot/blob/master/tsconfig.json
https://github.com/probot/probot/blob/master/src/context.ts#L11

I also reviewed the only other fork of argocd-bot, and they completely removed the unit tests, which I don't want to do.

https://github.com/mr-sour/argocd-bot/blob/master/Dockerfile#L43

There are also a number of packages that are out of date and have vulnerabilities. I have another PR which at least mitigates this by only allowing traffic from github, but this is something that should be fixed. The problem with updating all the packages is that the unit tests stop working, which will take some time to investigate and it appears will require a good bit of fixes.

My intention is to explore using `eslint` instead, since it's the replacement for `tslint`, and might include some more fine grained control over what `tslint` errors are ignored for dependencies.

The changes for the nock import were taken directly from the documentation for nock. https://github.com/nock/nock

**Question** Did I configure the service.yaml correctly? The unit tests run as part of the docker build, so I wasn't sure if that works correctly here or not.