### PR TITLE
fix missing ca certs for argobot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ARGOCD_VERSION=latest
+ARG ARGOCD_VERSION=v1.7.5
 FROM argoproj/argocd:$ARGOCD_VERSION as argocd
 
 FROM node:12.19.0-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM argoproj/argocd:$ARGOCD_VERSION as argocd
 FROM node:12.19.0-slim
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y git apt-utils sudo python make vim procps && \
+    apt-get --no-install-recommends install -y git apt-utils sudo python make vim procps ca-certificates && \
     apt-get clean && \
     rm -rf \
         /var/lib/apt/lists/* \
@@ -13,6 +13,8 @@ RUN apt-get update && \
         /usr/share/man \
         /usr/share/doc \
         /usr/share/doc-base
+
+RUN update-ca-certificates
 
 WORKDIR /home/argocd/argocd-bot
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argo-bot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Simple Argo but to comment with diffs on PR",
   "repository": "https://github.com/ezcater/argocd-bot",
   "licenses": [


### PR DESCRIPTION
It looks like the image running now doesn't have the ca-certificates.crt file, so any of the git operations are failing with this error.

`fatal: unable to access 'https://<token-redacted>:x-oauth-basic@github.com/ezcater/lab-kubernetes-cluster/': Problem with the SSL CA cert (path? access rights?)`

I'm not really sure how other tools are able to invoke the github api, maybe node is using its own ca bundle? I'm open to suggestions for handling this differently, it looks like git has some options as well.